### PR TITLE
Add patch command to isucon3-qualifier playbook

### DIFF
--- a/isucon3-qualifier/playbook.yml
+++ b/isucon3-qualifier/playbook.yml
@@ -5,6 +5,7 @@
     - yum: name=libselinux-python
     - yum: name=epel-release
     - yum: name=git
+    - yum: name=patch
 
     # SELinux
     - selinux: state=disabled


### PR DESCRIPTION
I got this error on master branch.

```
TASK: [shell .xbuild/perl-install 5.18.1 /home/isucon/local/perl-5.18] ********
failed: [localhost] => {"changed": true, "cmd": ".xbuild/perl-install 5.18.1 /home/isucon/local/perl-5.18", "delta": "0:00:20.701160", "end": "2015-09-23 14:37:31.659668", "rc": 1, "start": "2015-09-23 14:37:10.958508", "warnings": []}
stdout: Start to build perl 5.18.1 ...
perl-build failed. see log: /tmp/isucon-perl-install.log

FATAL: all hosts have already failed -- aborting
```

Then, I checked the log file on VM.

```
$ cat /tmp/isucon-perl-install.log
Fetching 5.18.1 as /tmp/bpPKE1FqQN/perl-5.18.1.tar.gz (http://www.cpan.org/authors/id/R/RJ/RJBS/perl-5.18.1.tar.gz)
Downloaded http://www.cpan.org/authors/id/R/RJ/RJBS/perl-5.18.1.tar.gz to /tmp/bpPKE1FqQN/perl-5.18.1.tar.gz.
Configuring perl '5.18.1'
rm -f config.sh Policy.sh
Auto-guessed '5.18.1'
No patch utility found
patching ext/Errno/Errno_pm.PL
```

I guess `.xbuild/perl-install` requires `patch` command.
